### PR TITLE
remove redundant YYLOC global declaration

### DIFF
--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,7 +637,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \


### PR DESCRIPTION
yylloc is declared two times. Until kernel <5.6 the _shipped files are used instead of source - so differing from the commit e33a814e [1], one of the two definitions have be declared extern

gcc10 will not compile as is because of defaulting to -fcommon

for context see
[1] https://github.com/torvalds/linux/commit/e33a814e772cdc36436c8c188d8c42d019fda639 [2] https://lkml.org/lkml/2020/3/31/658